### PR TITLE
Updates To Inspector Window and Window Manager

### DIFF
--- a/Include/Inspector/InspectorWindow.h
+++ b/Include/Inspector/InspectorWindow.h
@@ -17,20 +17,22 @@ namespace PlatinumEngine
 	class InspectorWindow
 	{
 	public:
-		explicit InspectorWindow(Scene &scene);
-		void ShowGUIWindow(bool* isOpen);
+		InspectorWindow() = default;
+		void ShowGUIWindow(bool* isOpen, Scene& scene);
 		void SetActiveGameObject(GameObject* gameObject);
 	private:
 		// TODO: Add specific component guis as components are created
-		void ShowMeshRenderComponent();
-		void ShowTransformComponent();
+		void ShowMeshRenderComponent(Scene& scene);
+		void ShowTransformComponent(Scene& scene);
 
 		// Shown when add component button pressed
-		void ShowAddComponent();
+		void ShowAddComponent(Scene& scene);
 	private:
-		Scene &_scene;
 		GameObject* _activeGameObject = nullptr;
 		std::string _meshFileName;
 		bool _isAddComponentWindowOpen = false;
+
+		// Have to keep track of if object enabled ourselves as isEnabled is a private member of game object
+		bool _isObjectEnabled;
 	};
 }

--- a/Include/WindowManager/WindowManager.h
+++ b/Include/WindowManager/WindowManager.h
@@ -11,17 +11,17 @@ namespace PlatinumEngine
 	class WindowManager
 	{
 	public:
-		explicit WindowManager(Scene &scene);
+		WindowManager() = default;
 
 		///-----------------------------------
 		///Main menu bar functions
 		///-----------------------------------
 		//window section
-		void ShowGUI();
+		void ShowGUI(Scene &scene);
 		void ShowMenuFile();
-		void ShowMenuGameObject();
+		void ShowMenuGameObject(Scene &scene);
         void ShowMenuEdit();
-		void SetUpMainMenu();
+		void SetUpMainMenu(Scene &scene);
 
         //file section
         void LoadFile();
@@ -73,8 +73,5 @@ namespace PlatinumEngine
 		///-----------------------------------------------------------------------
 	    bool _showFileLoad          		 = false;
 	    bool _showFileSave                   = false;
-
-	private:
-		Scene &_scene;
 	};
 }

--- a/Source/Inspector/InspectorWindow.cpp
+++ b/Source/Inspector/InspectorWindow.cpp
@@ -6,33 +6,37 @@
 
 using namespace PlatinumEngine;
 
-InspectorWindow::InspectorWindow(Scene& scene) : _scene(scene)
-{
-}
-
-void InspectorWindow::ShowGUIWindow(bool* isOpen)
+void InspectorWindow::ShowGUIWindow(bool* isOpen, Scene& scene)
 {
 	ImGui::Begin("Inspector Window", isOpen);
 
 	if (_activeGameObject)
 	{
-		ImGui::Text("Object Name: ");
+		ImGui::Text("Name: ");
 		ImGui::SameLine();
 		static char objectNameBuffer[128];
 		strcpy(objectNameBuffer, _activeGameObject->name.c_str());
 		ImGui::InputText("##input name", objectNameBuffer, IM_ARRAYSIZE(objectNameBuffer));
 		_activeGameObject->name = std::string{objectNameBuffer};
 
-		// Now render each component gui
-		if (_activeGameObject->GetComponent<RenderComponent>()!= nullptr)
-			ShowMeshRenderComponent();
+		ImGui::SameLine();
 
-		if (_activeGameObject->GetComponent<TransformComponent>()!= nullptr)
-			ShowTransformComponent();
+		if (ImGui::Checkbox("##IsEnabled", &_isObjectEnabled))
+		{
+			_activeGameObject->SetEnabled(_isObjectEnabled, scene);
+		}
+
+		// Now render each component gui
+		if (_activeGameObject->GetComponent<RenderComponent>() != nullptr)
+			ShowMeshRenderComponent(scene);
+
+		if (_activeGameObject->GetComponent<TransformComponent>() != nullptr)
+			ShowTransformComponent(scene);
 
 		ImGui::Separator();
 		if (_isAddComponentWindowOpen)
-			ShowAddComponent();
+			ShowAddComponent(scene);
+
 		if (ImGui::Button("Add Component")) {
 			_isAddComponentWindowOpen = !_isAddComponentWindowOpen;
 		}
@@ -44,18 +48,24 @@ void InspectorWindow::ShowGUIWindow(bool* isOpen)
 void InspectorWindow::SetActiveGameObject(GameObject* gameObject)
 {
 	_activeGameObject = gameObject;
+
+	// Get states of gameObject if not null
+	if (gameObject)
+	{
+		_isObjectEnabled = gameObject->IsEnabled();
+	}
 }
 
-void InspectorWindow::ShowMeshRenderComponent()
+void InspectorWindow::ShowMeshRenderComponent(Scene& scene)
 {
 	ImGui::Separator();
 	static char meshBuffer[128];
 	bool isHeaderOpen = ImGui::CollapsingHeader("Mesh Render Component", ImGuiTreeNodeFlags_AllowItemOverlap);
 	// TODO: Icon button maybe?
 	ImGui::SameLine((ImGui::GetWindowContentRegionMax().x - ImGui::GetWindowContentRegionMin().x) - 4.0f);
-	if (ImGui::Button("X")) {
+	if (ImGui::Button("X##RemoveRenderComponent")) {
 		// remove component
-		_scene.RemoveComponent(*_activeGameObject->GetComponent<RenderComponent>());
+		scene.RemoveComponent(*_activeGameObject->GetComponent<RenderComponent>());
 		return;
 	}
 	if (isHeaderOpen)
@@ -82,21 +92,21 @@ void InspectorWindow::ShowMeshRenderComponent()
 	strncpy(meshBuffer, _meshFileName.c_str(), sizeof(meshBuffer));
 }
 
-void InspectorWindow::ShowTransformComponent()
+void InspectorWindow::ShowTransformComponent(Scene& scene)
 {
 	// If this gui is being shown, assumption that object has transform component
 	ImGui::Separator();
 	bool isHeaderOpen = ImGui::CollapsingHeader("Transform Component", ImGuiTreeNodeFlags_AllowItemOverlap);
 	// TODO: Icon button maybe?
 	ImGui::SameLine((ImGui::GetWindowContentRegionMax().x - ImGui::GetWindowContentRegionMin().x) - 4.0f);
-	if (ImGui::Button("X")) {
+	if (ImGui::Button("X##RemoveTransformComponent")) {
 		// remove component
-		_scene.RemoveComponent(*_activeGameObject->GetComponent<TransformComponent>());
+		scene.RemoveComponent(*_activeGameObject->GetComponent<TransformComponent>());
 		return;
 	}
 	if (isHeaderOpen)
 	{
-		ImGui::PushItemWidth(80);
+		ImGui::PushItemWidth(50);
 		ImGui::Text("Position: ");
 		ImGui::SameLine();
 		ImGui::Text("X");
@@ -145,7 +155,7 @@ void InspectorWindow::ShowTransformComponent()
 	}
 }
 
-void InspectorWindow::ShowAddComponent()
+void InspectorWindow::ShowAddComponent(Scene& scene)
 {
 	if (ImGui::BeginChild("ComponentSelector"))
 	{
@@ -186,12 +196,12 @@ void InspectorWindow::ShowAddComponent()
 			if (strcmp(selectedComponent, "Mesh Render Component") == 0)
 			{
 				// Add Render Component
-				_scene.AddComponent<RenderComponent>(_activeGameObject);
+				scene.AddComponent<RenderComponent>(_activeGameObject);
 			}
 			else if (strcmp(selectedComponent, "Transform Component") == 0)
 			{
 				// Add Transform Component
-				_scene.AddComponent<TransformComponent>(_activeGameObject);
+				scene.AddComponent<TransformComponent>(_activeGameObject);
 			}
 			_isAddComponentWindowOpen = false;
 			selectedComponent = nullptr;

--- a/Source/WindowManager/WindowManager.cpp
+++ b/Source/WindowManager/WindowManager.cpp
@@ -9,14 +9,10 @@
 
 namespace PlatinumEngine
 {
-	WindowManager::WindowManager(Scene& scene) : _scene(scene)
-	{
-	}
-
 	///--------------------------------------------------------------------------
 	/// this function will create a basic window when you open the Platinum Engine
 	///--------------------------------------------------------------------------
-	void WindowManager::ShowGUI()
+	void WindowManager::ShowGUI(Scene &scene)
 	{
 		///-----------------------------------------------------------------------
 		///ifs in main menu window list to call the function inside
@@ -37,13 +33,13 @@ namespace PlatinumEngine
 		///-------------------------------------------------------------------
 		/// set up the main menu bar
 		///-------------------------------------------------------------------
-		SetUpMainMenu();
+		SetUpMainMenu(scene);
 	}
 
 	///--------------------------------------------------------------------------
 	/// Set up the main menu for basic Window
 	///--------------------------------------------------------------------------
-	void WindowManager::SetUpMainMenu()
+	void WindowManager::SetUpMainMenu(Scene &scene)
 	{
 		if (ImGui::BeginMainMenuBar())
 		{
@@ -68,7 +64,7 @@ namespace PlatinumEngine
 			///---------------------------------------------------------------
 			if (ImGui::BeginMenu("GameObject"))
 			{
-				ShowMenuGameObject();
+				ShowMenuGameObject(scene);
 				ImGui::EndMenu();
 			}
 			///---------------------------------------------------------------
@@ -136,11 +132,11 @@ namespace PlatinumEngine
 	/// this function helps to create a list of
 	/// operations of "GameObject" in the menu Bar
 	///--------------------------------------------------------------------------
-	void WindowManager::ShowMenuGameObject()
+	void WindowManager::ShowMenuGameObject(Scene &scene)
 	{
 		if (ImGui::MenuItem("Create Empty"))
 		{
-			_scene.AddGameObject();
+			scene.AddGameObject();
 		}
 
 		if (ImGui::BeginMenu("3D Object"))

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -84,9 +84,9 @@ int main(int, char**)
 		PlatinumEngine::HierarchyWindow hierarchyWindow;
 
 		bool isInspectorWindowOpen = true;
-		PlatinumEngine::InspectorWindow inspectorWindow(scene);
+		PlatinumEngine::InspectorWindow inspectorWindow;
 
-		PlatinumEngine::WindowManager windowManager(scene);
+		PlatinumEngine::WindowManager windowManager;
 
 		// Main loop
 		while (!glfwWindowShouldClose(window))
@@ -108,20 +108,19 @@ int main(int, char**)
 			if(isInputWindowOpen)
 				inputManager.ShowGUIWindow(&isInputWindowOpen);
 
-			if(isInputWindowOpen)
-				inputManager.ShowGUIWindow(&isInputWindowOpen);
 			if(isHierarchyWindowOpen)
 			{
 				hierarchyWindow.ShowGUIWindow(&isHierarchyWindowOpen, scene);
 				inspectorWindow.SetActiveGameObject(hierarchyWindow.selectedGameObject);
-
-				if(isInspectorWindowOpen)
-					inspectorWindow.ShowGUIWindow(&isInspectorWindowOpen);
 			}
+
+			if(isInspectorWindowOpen)
+				inspectorWindow.ShowGUIWindow(&isInspectorWindowOpen, scene);
+
 			if(isLoggerOpen)
 				logger.ShowGUIWindow(&isLoggerOpen);
 
-			windowManager.ShowGUI();
+			windowManager.ShowGUI(scene);
 			//ImGui::ShowDemoWindow();
 			//--------------------------------------------------------------------------------------------------------------
 			// END OF GUI


### PR DESCRIPTION
~~**WAIT BEFORE MERGING MAKING SOME UPDATES**~~

Previously scene was set in constructor and couldn't be changed. By passing scene as an arg to ShowGuiWindow scene will always be the correct one. Also fixed a small bug where you couldn't remove a transform component if a render component exists because the remove buttons had the same ID. Also, inspector window should be able to be opened even without the hierarchy window open. This is because in future version, you should be able to click and object in the scene itself and display it's information in the inspector window without the need for a hierarchy window to even be open.

To Test:
Click GameObject at the top
Click AddEmpty
Click on GameObject in hierarchy window, should display in inspector window
Add mesh render and transform component
Should be able to remove transform component first before mesh render