### PR TITLE
New gizmos

### DIFF
--- a/Include/ComponentComposition/TransformComponent.h
+++ b/Include/ComponentComposition/TransformComponent.h
@@ -19,6 +19,7 @@ namespace PlatinumEngine
 
 		Maths::Vec3 localPosition;
 		Maths::Quaternion localRotation;
+		Maths::Mat4 transformationMatrix;
 		// uniform scaling has nice properties
 		float localScale;
 
@@ -44,6 +45,8 @@ namespace PlatinumEngine
 		 * @param target
 		 */
 		void LookAt(Maths::Vec3 target);
+
+		void SetLocalToWorldMatrix(Maths::Mat4 LocalToWorld);
 
 		//Transforms direction from local space to parent space
 		Maths::Vec3 LocalToParentDirection(Maths::Vec3 dir);

--- a/Include/Inspector/InspectorWindow.h
+++ b/Include/Inspector/InspectorWindow.h
@@ -29,6 +29,8 @@ namespace PlatinumEngine
 
 		// Shown when add component button pressed
 		void ShowAddComponent(Scene& scene);
+
+		void cameraComponentHelper(char* cameraType[]);
 	private:
 		AssetHelper* _assetHelper;
 		GameObject* _activeGameObject = nullptr;
@@ -39,8 +41,9 @@ namespace PlatinumEngine
 		bool _isObjectEnabled;
 
 		//ImGui helper parameters
-		float _sameLineMesh = 70.f;
 		float _itemWidthMesh = 160.f;
-		float _sameLineTransform = 70.f;
+		float _sameLine = 140.f;
+		std::vector<std::string> _temp = {"Perspective", "Orthographic"};
+		std::vector<std::string> _clearMode = {"None", "SkyBox", "BackgroundColour"};
 	};
 }

--- a/Include/Maths/Matrices.h
+++ b/Include/Maths/Matrices.h
@@ -183,7 +183,8 @@ namespace PlatinumEngine
 
 			void Decompose(
 					Maths::Vec3* outTranslation,
-					Maths::Quaternion* outQuaternion) const;
+					Maths::Quaternion* outQuaternion,
+					float* scale) const;
 
 		};
 

--- a/Source/ComponentComposition/TransformComponent.cpp
+++ b/Source/ComponentComposition/TransformComponent.cpp
@@ -1,5 +1,5 @@
 #include "ComponentComposition/TransformComponent.h"
-
+#include <ImGuizmo.h>
 namespace PlatinumEngine
 {
 	//Constructors
@@ -49,12 +49,12 @@ namespace PlatinumEngine
 
 	Maths::Mat4 TransformComponent::GetLocalToWorldMatrix()
 	{
-		Maths::Mat4 localToParent = GetLocalToParentMatrix();
+		Maths::Mat4 transformMatrix = GetLocalToParentMatrix();
 		TransformComponent* transform = GetParentComponent<TransformComponent>();
 		if (transform)
 			// recursive, slow but oh well
-			return transform->GetLocalToWorldMatrix() * localToParent;
-		return localToParent;
+			return transform->GetLocalToWorldMatrix() * transformMatrix;
+		return transformMatrix;
 	}
 
 	Maths::Mat4 TransformComponent::GetLocalToParentMatrix()
@@ -78,4 +78,18 @@ namespace PlatinumEngine
 	{
 		return localRotation * Maths::Vec3::right;
 	}
+
+	void TransformComponent::SetLocalToWorldMatrix(Maths::Mat4 LocalToWorld)
+	{
+		Maths::Mat4 ParentToWorld, LocalToParent;
+		auto parent = GetParentComponent<TransformComponent>();
+		if (parent)
+			ParentToWorld = parent->GetLocalToWorldMatrix();
+		else
+			ParentToWorld.SetIdentityMatrix();
+
+		LocalToParent = Inverse(ParentToWorld) * LocalToWorld;
+		LocalToParent.Decompose(&localPosition, &localRotation, &localScale);
+	}
+
 }

--- a/Source/Inspector/InspectorWindow.cpp
+++ b/Source/Inspector/InspectorWindow.cpp
@@ -80,7 +80,7 @@ void InspectorWindow::ShowMeshRenderComponent(Scene& scene)
 	if (isHeaderOpen)
 	{
 		ImGui::Text("Mesh");
-		ImGui::SameLine(_sameLineMesh);
+		ImGui::SameLine(_sameLine);
 		ImGui::PushItemWidth(_itemWidthMesh);
 
 		// store the current mesh name into mesh buffer, so that we can display it in the input text box
@@ -115,7 +115,7 @@ void InspectorWindow::ShowMeshRenderComponent(Scene& scene)
 		//Show text box (read only)----------Choose Material
 		ImGui::Separator();
 		ImGui::Text("Material");
-		ImGui::SameLine(_sameLineMesh);
+		ImGui::SameLine(_sameLine);
 		ImGui::PushItemWidth(_itemWidthMesh);
 
 		// store the current material name into mesh buffer, so that we can display it in the input text box
@@ -133,7 +133,7 @@ void InspectorWindow::ShowMeshRenderComponent(Scene& scene)
 				_activeGameObject->GetComponent<RenderComponent>()->SetMaterial(std::get<1>(asset_Helper));
 		}
 		ImGui::Text("Shininess");
-		ImGui::SameLine(_sameLineMesh);
+		ImGui::SameLine(_sameLine);
 		ImGui::PushItemWidth(_itemWidthMesh);
 		ImGui::SliderFloat("##shininess",&(_activeGameObject->GetComponent<RenderComponent>()->material.shininessFactor),0.f, 100.f, "%.3f", ImGuiSliderFlags_None);
 		ImGui::PopItemWidth();
@@ -154,27 +154,24 @@ void InspectorWindow::ShowTransformComponent(Scene& scene)
 	}
 	if (isHeaderOpen)
 	{
- 		static float translation[3] = {0.f, 0.f, 0.f};
 		ImGui::PushItemWidth(50);
 		ImGui::Text("Position: ");
-		ImGui::SameLine(_sameLineTransform);
+		ImGui::SameLine(_sameLine -16.f);
 		ImGui::Text("X");
 		ImGui::SameLine();
-		ImGui::InputFloat("##Xpos", &translation[0]);
+		ImGui::InputFloat("##Xpos", &_activeGameObject->GetComponent<TransformComponent>()->localPosition[0]);
 		ImGui::SameLine();
 		ImGui::Text("Y");
 		ImGui::SameLine();
-		ImGui::InputFloat("##Ypos", &translation[1]);
+		ImGui::InputFloat("##Ypos", &_activeGameObject->GetComponent<TransformComponent>()->localPosition[1]);
 		ImGui::SameLine();
 		ImGui::Text("Z");
 		ImGui::SameLine();
-		ImGui::InputFloat("##Zpos", &translation[2]);
-		_activeGameObject->GetComponent<TransformComponent>()->localPosition =
-				Maths::Vec3(translation[0], translation[1], translation[2]);
+		ImGui::InputFloat("##Zpos", &_activeGameObject->GetComponent<TransformComponent>()->localPosition[2]);
 
-		static float eulerRotation[3] = {0.0f, 0.0f, 0.0f};
+		Maths::Vec3 eulerRotation = _activeGameObject->GetComponent<TransformComponent>()->localRotation.EulerAngles();
 		ImGui::Text("Rotation: ");
-		ImGui::SameLine(_sameLineTransform);
+		ImGui::SameLine(_sameLine - 16.f);
 		ImGui::Text("X");
 		ImGui::SameLine();
 		ImGui::InputFloat("##Xrot", &eulerRotation[0]);
@@ -185,20 +182,22 @@ void InspectorWindow::ShowTransformComponent(Scene& scene)
 		ImGui::SameLine();
 		ImGui::Text("Z");
 		ImGui::SameLine();
-		ImGui::InputFloat("##Zrpt", &eulerRotation[2]);
+		ImGui::InputFloat("##Zrot", &eulerRotation[2]);
 		_activeGameObject->GetComponent<TransformComponent>()->localRotation = Maths::Quaternion::EulerToQuaternion(
 				Maths::Vec3(eulerRotation[0], eulerRotation[1], eulerRotation[2]));
 
-		static float scale[3] = {0.f, 0.f, 0.f};
-		ImGui::Text("Scale:    ");
-		ImGui::SameLine();
+		ImGui::Text("Scale: ");
+		ImGui::SameLine(_sameLine);
 		ImGui::InputFloat("##scale", &_activeGameObject->GetComponent<TransformComponent>()->localScale);
 		ImGui::PopItemWidth();
 	}
+
 }
 
 void InspectorWindow::ShowCameraComponent(Scene& scene)
 {
+	char cameraType[64];
+	char clearMode[64];
 	// If this gui is being shown, assumption that object has transform component
 	ImGui::Separator();
 	bool isHeaderOpen = ImGui::CollapsingHeader(ICON_FA_CAMERA "  Camera", ImGuiTreeNodeFlags_AllowItemOverlap);
@@ -213,28 +212,89 @@ void InspectorWindow::ShowCameraComponent(Scene& scene)
 	{
 		auto camera = _activeGameObject->GetComponent<CameraComponent>();
 
-//		IMGUI_API bool          BeginListBox(const char* label, const ImVec2& size = ImVec2(0, 0)); // open a framed scrolling region
-//		IMGUI_API void          EndListBox();                                                       // only call EndListBox() if BeginListBox() returned true!
-//		IMGUI_API bool          ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items = -1);
-//		IMGUI_API bool          ListBox(const char* label, int* current_item, bool (*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int height_in_items = -1);
+		{// the camera projection type
+			if (CameraComponent::ProjectionType::perspective == camera->projectionType)
+			{
+				std::strcpy(cameraType, _temp[0].c_str());
+			}
+			if (CameraComponent::ProjectionType::orthographic == camera->projectionType)
+			{
 
-		const char* projectionTypes[] = { "perspective", "orthographic" };
-		ImGui::ListBox(
-				"Projection Type",
-				(int*)(&camera->projectionType),
-				projectionTypes,
-				IM_ARRAYSIZE(projectionTypes));
+				std::strcpy(cameraType, _temp[1].c_str());
+			}
 
-		const char* clearModes[] = {"none", "backgroundColor","skybox" };
-		ImGui::ListBox(
-				"Clear Mode",
-				(int*)(&camera->clearMode),
-				clearModes,
-				IM_ARRAYSIZE(clearModes));
+			ImGui::Text("Projection Type");
+			ImGui::SameLine(_sameLine);
+			ImGui::SetNextItemWidth(_itemWidthMesh);
+			ImGui::InputText("##Projection Type", cameraType, sizeof(cameraType), ImGuiInputTextFlags_ReadOnly);
+			ImGui::SameLine();
+			if (ImGui::BeginPopupContextItem("projection type"))
+			{
+				if (ImGui::Selectable("Perspective"))
+				{
+					camera->projectionType = CameraComponent::ProjectionType::perspective;
+					//std::strcpy(cameraType, _temp[0].c_str());
+				}
+				if (ImGui::Selectable("Orthographic"))
+				{
+					camera->projectionType = CameraComponent::ProjectionType::orthographic;
+					//std::strcpy(cameraType, _temp[1].c_str());
+				}
+				ImGui::EndPopup();
+			}
 
+			if (ImGui::Button(ICON_FA_CARET_DOWN "##projectionType"))
+			{
+				ImGui::OpenPopup("projection type");
+			}
+		}
+
+		{// the camera clear mode
+			if (CameraComponent::ClearMode::backgroundColor == camera->clearMode)
+			{
+				std::strcpy(clearMode, _clearMode[2].c_str());
+			}
+			if (CameraComponent::ClearMode::skybox == camera->clearMode)
+			{
+				std::strcpy(clearMode, _clearMode[1].c_str());
+			}
+			if (CameraComponent::ClearMode::none == camera->clearMode)
+			{
+				std::strcpy(clearMode, _clearMode[0].c_str());
+			}
+
+
+			ImGui::Text("Clear Mode");
+			ImGui::SameLine(_sameLine);
+			ImGui::SetNextItemWidth(_itemWidthMesh);
+			ImGui::InputText("##Clear Mode", clearMode, sizeof(clearMode), ImGuiInputTextFlags_ReadOnly);
+			ImGui::SameLine();
+			if (ImGui::BeginPopupContextItem("clear mode"))
+			{
+				if (ImGui::Selectable("SkyBox"))
+				{
+					camera->clearMode = CameraComponent::ClearMode::skybox;
+				}
+				if (ImGui::Selectable("None"))
+				{
+					camera->clearMode = CameraComponent::ClearMode::none;
+				}
+				if (ImGui::Selectable("BackgroundColour"))
+				{
+					camera->clearMode = CameraComponent::ClearMode::backgroundColor;
+				}
+				ImGui::EndPopup();
+			}
+
+			if (ImGui::Button(ICON_FA_CARET_DOWN "##ClearMode"))
+			{
+				ImGui::OpenPopup("clear mode");
+			}
+		}
+		ImGui::Separator();
 		ImGui::PushItemWidth(50);
 		ImGui::Text("Background color: ");
-		ImGui::SameLine();
+		ImGui::SameLine(_sameLine - 16.f);
 		ImGui::Text("R");
 		ImGui::SameLine();
 		ImGui::InputFloat("##Red", &camera->backgroundColor.r);
@@ -257,19 +317,19 @@ void InspectorWindow::ShowCameraComponent(Scene& scene)
 		float orthographicSize;
 
 		ImGui::Text("Field of View: ");
-		ImGui::SameLine();
+		ImGui::SameLine(_sameLine);
 		ImGui::InputFloat("##FOV", &camera->fov);
 
 		ImGui::Text("Near Clipping Plane: ");
-		ImGui::SameLine();
+		ImGui::SameLine(_sameLine);
 		ImGui::InputFloat("##NearClippingPlane", &camera->nearClippingPlane);
 
 		ImGui::Text("Far Clipping Plane: ");
-		ImGui::SameLine();
+		ImGui::SameLine(_sameLine);
 		ImGui::InputFloat("##FarClippingPlane", &camera->farClippingPlane);
 
 		ImGui::Text("Orthographic Size: ");
-		ImGui::SameLine();
+		ImGui::SameLine(_sameLine);
 		ImGui::InputFloat("##OrthographicSize", &camera->orthographicSize);
 	}
 }

--- a/Source/Inspector/InspectorWindow.cpp
+++ b/Source/Inspector/InspectorWindow.cpp
@@ -4,6 +4,7 @@
 
 #include <Inspector/InspectorWindow.h>
 #include <ComponentComposition/CameraComponent.h>
+#include <ImGuizmo.h>
 
 using namespace PlatinumEngine;
 
@@ -153,20 +154,23 @@ void InspectorWindow::ShowTransformComponent(Scene& scene)
 	}
 	if (isHeaderOpen)
 	{
+ 		static float translation[3] = {0.f, 0.f, 0.f};
 		ImGui::PushItemWidth(50);
 		ImGui::Text("Position: ");
 		ImGui::SameLine(_sameLineTransform);
 		ImGui::Text("X");
 		ImGui::SameLine();
-		ImGui::InputFloat("##Xpos", &_activeGameObject->GetComponent<TransformComponent>()->localPosition[0]);
+		ImGui::InputFloat("##Xpos", &translation[0]);
 		ImGui::SameLine();
 		ImGui::Text("Y");
 		ImGui::SameLine();
-		ImGui::InputFloat("##Ypos", &_activeGameObject->GetComponent<TransformComponent>()->localPosition[1]);
+		ImGui::InputFloat("##Ypos", &translation[1]);
 		ImGui::SameLine();
 		ImGui::Text("Z");
 		ImGui::SameLine();
-		ImGui::InputFloat("##Zpos", &_activeGameObject->GetComponent<TransformComponent>()->localPosition[2]);
+		ImGui::InputFloat("##Zpos", &translation[2]);
+		_activeGameObject->GetComponent<TransformComponent>()->localPosition =
+				Maths::Vec3(translation[0], translation[1], translation[2]);
 
 		static float eulerRotation[3] = {0.0f, 0.0f, 0.0f};
 		ImGui::Text("Rotation: ");
@@ -185,6 +189,7 @@ void InspectorWindow::ShowTransformComponent(Scene& scene)
 		_activeGameObject->GetComponent<TransformComponent>()->localRotation = Maths::Quaternion::EulerToQuaternion(
 				Maths::Vec3(eulerRotation[0], eulerRotation[1], eulerRotation[2]));
 
+		static float scale[3] = {0.f, 0.f, 0.f};
 		ImGui::Text("Scale:    ");
 		ImGui::SameLine();
 		ImGui::InputFloat("##scale", &_activeGameObject->GetComponent<TransformComponent>()->localScale);

--- a/Source/Maths/Matrices.cpp
+++ b/Source/Maths/Matrices.cpp
@@ -237,7 +237,7 @@ namespace PlatinumEngine
 			if (outQuaternion)
 				*outQuaternion = {quaternion.w, quaternion.x, quaternion.y, quaternion.z};
 			if(outScale)
-				*outScale = std::max({scale.x, scale.y, scale.z});
+				*outScale = std::max(std::max(scale.x, scale.y), scale.z);
 		}
 
 		Mat3 Mat3::operator*(float scale)

--- a/Source/Maths/Matrices.cpp
+++ b/Source/Maths/Matrices.cpp
@@ -219,7 +219,8 @@ namespace PlatinumEngine
 
 		void Mat4::Decompose(
 				Maths::Vec3* outTranslation,
-				Maths::Quaternion* outQuaternion) const
+				Maths::Quaternion* outQuaternion,
+				float* outScale) const
 		{
 			glm::vec3 scale;
 			glm::quat quaternion;
@@ -235,6 +236,8 @@ namespace PlatinumEngine
 				*outTranslation = {translation.x, translation.y , translation.z};
 			if (outQuaternion)
 				*outQuaternion = {quaternion.w, quaternion.x, quaternion.y, quaternion.z};
+			if(outScale)
+				*outScale = std::max({scale.x, scale.y, scale.z});
 		}
 
 		Mat3 Mat3::operator*(float scale)

--- a/Source/Maths/Quaternion.cpp
+++ b/Source/Maths/Quaternion.cpp
@@ -183,7 +183,7 @@ namespace PlatinumEngine
 		}
 		Vec3 Quaternion::EulerAngles()
 		{
-			return QuaternionToEuler(Quaternion(w,x,y,z))*Common::RAD2DEG;
+			return QuaternionToEuler(Quaternion(w,x,y,z));
 		}
 		Vec4 Quaternion::ToVec4()
 		{
@@ -314,7 +314,7 @@ namespace PlatinumEngine
 		Quaternion Quaternion::EulerToQuaternion(Vec3 euler)
 		{
 			glm::quat q{euler * Common::DEG2RAD};
-			return Quaternion(q.w,q.x,q.y,q.z);
+			return {q.w,q.x,q.y,q.z};
 		}
 
 		Mat4 Quaternion::QuaternionToMatrix(Quaternion q)

--- a/Source/SceneEditor/EditorCamera.cpp
+++ b/Source/SceneEditor/EditorCamera.cpp
@@ -86,9 +86,9 @@ namespace PlatinumEngine
 
 		// update translation value
 		if (wheelDelta < 0)
-			_translationValue += GetForwardDirection() * -_translationSpeed * 20.f;//* deltaClock.getElapsedTime().asSeconds();
+			_translationValue += GetForwardDirection() * -_translationSpeed * 5.f;//* deltaClock.getElapsedTime().asSeconds();
 		else if(wheelDelta > 0)
-			_translationValue += GetForwardDirection() * _translationSpeed * 20.f;//* deltaClock.getElapsedTime().asSeconds();
+			_translationValue += GetForwardDirection() * _translationSpeed * 5.f;//* deltaClock.getElapsedTime().asSeconds();
 
 		// update view matrix
 		UpdateViewMatrix();
@@ -112,10 +112,10 @@ namespace PlatinumEngine
 		}
 
 		// move along forward direction
-		_translationValue += forwardDirectionValue * GetForwardDirection() * _translationSpeed * 20.f;
+		_translationValue += forwardDirectionValue * GetForwardDirection() * _translationSpeed * 5.f;
 		// * deltaClock.getElapsedTime().asSeconds();
 
-		_translationValue += rightDirectionValue * GetRightDirection() * _translationSpeed * 20.f;
+		_translationValue += rightDirectionValue * GetRightDirection() * _translationSpeed * 5.f;
 		// * deltaClock.getElapsedTime().asSeconds();
 
 		// update view matrix
@@ -193,9 +193,9 @@ namespace PlatinumEngine
 	{
 		Maths::Vec3 translation;
 		Maths::Quaternion quaternion;
-
+		float scale;
 		// get translation and quaternion applied on the camera
-		viewMatrix4.Decompose(&translation, &quaternion);
+		viewMatrix4.Decompose(&translation, &quaternion, &scale);
 
 		quaternion =  Maths::Quaternion::Inverse(quaternion);
 

--- a/Source/SceneEditor/SceneEditor.cpp
+++ b/Source/SceneEditor/SceneEditor.cpp
@@ -374,12 +374,12 @@ namespace PlatinumEngine{
 			_renderer->SetModelMatrix();
 
 			// check if the view matrix is passed to shader
-			if(!_camera.CheckIfViewMatrixUsed())
+			//if(!_camera.CheckIfViewMatrixUsed())
 			{
 				_renderer->SetViewMatrix(_camera.viewMatrix4);
 				_camera.MarkViewMatrixAsUsed();
 			}
-			if(!_camera.CheckIfProjectionMatrixUsed())
+			//if(!_camera.CheckIfProjectionMatrixUsed())
 			{
 				_renderer->SetProjectionMatrix(_camera.projectionMatrix4);
 				_camera.MarkProjectionMatrixAsUsed();

--- a/Source/SceneEditor/SceneEditor.cpp
+++ b/Source/SceneEditor/SceneEditor.cpp
@@ -908,17 +908,21 @@ namespace PlatinumEngine{
 		float viewManipulateRight = ImGui::GetWindowPos().x + windowWidth;
 		float viewManipulateTop = ImGui::GetWindowPos().y;
 
+		if(_selectedGameobject != nullptr && _selectedGameobject->GetComponent<TransformComponent>() != nullptr)
+		{
+			auto transform =  _selectedGameobject->GetComponent<TransformComponent>();
+			Maths::Mat4 transform_matrix = transform->GetLocalToWorldMatrix();
+			ImGuizmo::Manipulate(
+					cameraView, cameraProjection, currentGizmoOperation, currentGizmoMode,
+					transform_matrix.matrix, NULL, _useSnap ? &_snap[0] : NULL,
+					_boundSizing ? _bounds : NULL, _boundSizingSnap ? _boundsSnap : NULL);
 
-		ImGuizmo::Manipulate(
-				cameraView, cameraProjection, currentGizmoOperation, currentGizmoMode,
-				identityMatrix.matrix, NULL, _useSnap ? &_snap[0] : NULL,
-				_boundSizing ? _bounds : NULL, _boundSizingSnap ? _boundsSnap : NULL);
+			transform->SetLocalToWorldMatrix(transform_matrix);
+		}
 
 		// view manipulate gizmo
 		ImGuizmo::ViewManipulate(cameraView, 0.001, ImVec2(viewManipulateRight - 100, viewManipulateTop),
 				ImVec2(100, 100), 0x10101010);
-
-
 	}
 
 }

--- a/Source/SceneEditor/SceneEditor.cpp
+++ b/Source/SceneEditor/SceneEditor.cpp
@@ -85,34 +85,35 @@ namespace PlatinumEngine{
 			ImGui::SameLine();
 			if (_currentGizmoOperation != ImGuizmo::SCALE)
 			{
-				/*
-				if (ImGui::RadioButton("Local", _currentGizmoMode == ImGuizmo::LOCAL))
-					_currentGizmoMode = ImGuizmo::LOCAL;
-				ImGui::SameLine();
-				if (ImGui::RadioButton("World", _currentGizmoMode == ImGuizmo::WORLD))
-					_currentGizmoMode = ImGuizmo::WORLD;
-*/
-				if (ImGui::Button(_imGuiButton ? ICON_FA_CUBE "##Local###ViewMode" : ICON_FA_EARTH_ASIA "##Global###ViewMode"))
+				if (ImGui::Button(_currentGizmoMode == ImGuizmo::LOCAL ? ICON_FA_CUBE "##Local###ViewMode" : ICON_FA_EARTH_ASIA "##Global###ViewMode"))
 				{
-					_imGuiButton = !_imGuiButton;
-					if (_imGuiButton)
-					{
-						_currentGizmoMode = ImGuizmo::LOCAL;
-					}
-					else if (!_imGuiButton)
+					if (_currentGizmoMode == ImGuizmo::LOCAL)
 					{
 						_currentGizmoMode = ImGuizmo::WORLD;
+					}
+					else if (_currentGizmoMode == ImGuizmo::WORLD)
+					{
+						_currentGizmoMode = ImGuizmo::LOCAL;
 					}
 				}
 				if (ImGui::IsItemHovered())
 				{
-					if(_imGuiButton)
+					if(_currentGizmoMode == ImGuizmo::LOCAL)
 						ImGui::SetTooltip("Local gizmo");
-					if(!_imGuiButton)
+					if(_currentGizmoMode == ImGuizmo::WORLD)
 						ImGui::SetTooltip("Global gizmo");
 				}
 
 			}
+			else if(_currentGizmoOperation == ImGuizmo::SCALE)
+			{
+				ImGui::Button( ICON_FA_CUBE "##Local###ViewMode");
+				if (ImGui::IsItemHovered())
+				{
+					ImGui::SetTooltip("Local Only Under Scale");
+				}
+			}
+
 			ImGui::SameLine();
 			if (ImGui::Button(ICON_FA_ARROWS_UP_DOWN_LEFT_RIGHT "##Translate"))
 				_currentGizmoOperation = ImGuizmo::TRANSLATE;

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -53,7 +53,7 @@ int main(int, char**)
 
 		 const ImWchar ke_icons_ranges[] = { ICON_MIN_KI, ICON_MAX_KI, 0 };
 		 const ImWchar aw_icons_ranges[] = { ICON_MIN_FA, ICON_MAX_FA, 0};
-		 const ImWchar md_icons_ranges[] = { ICON_MIN_MD, ICON_MAX_KI, 0};
+		 const ImWchar md_icons_ranges[] = { ICON_MIN_MD, 0xf900, 0};
 		ImFontConfig config;
 		config.MergeMode = true;
 		io.Fonts->AddFontFromFileTTF("./Fonts/NotoSansDisplay-Regular.ttf", 18.0f);


### PR DESCRIPTION
1. this branch is included the most recent renderer branch
2. this branch completes the object gizmo with a small bug
------------------------------------------------------------------

- The inspector Window is fully upgraded with some alignment
- You can use the object gizmo when you attach a transform component to it
- Editor camera bug is half fixed by Shihua, but the coordinate is opposite to the gizmo coordinate 
- New icons
- The grid and skybox button on the top of the scene editor( which is not enabled, because grid and skybox are not finished)
- fix the camera bug in the scene editor that conflicts with the camera component 

-----------------------------------------------------------------
way to test:

1. check the inspector window if the textboxes are all in alignment 
2. check the viewGizmo and object gizmo based on transform component is working or not ( the object gizmo needs to be attached to the transform component first, and it will not work for some times and I don't know why)
3. test the icons on the top of the scene editor:

- Click the translate, rotate, scale button on the top of the scene editor to see if it is switched to the correct gizmo
- The local and global button will not work after you choose the scale button, because there are no global scale for our object
- The skybox and grid button is not working right now so leave it